### PR TITLE
Fix MessagesProxy to fully support MessageFormat syntax

### DIFF
--- a/src/main/java/com/teklabs/gwt/i18n/server/MessagesProxy.java
+++ b/src/main/java/com/teklabs/gwt/i18n/server/MessagesProxy.java
@@ -1,21 +1,26 @@
 package com.teklabs.gwt.i18n.server;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 import com.google.gwt.i18n.client.LocalizableResource;
 import com.google.gwt.i18n.client.Messages;
 import com.google.gwt.i18n.client.PluralRule;
 import com.google.gwt.i18n.client.impl.plurals.DefaultRule;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.*;
-import java.util.regex.Matcher;
-
 /**
  * @author Vladimir Kulev
  */
 class MessagesProxy extends LocaleProxy {
-    private Map<Object, PluralRule> rules = new HashMap<Object, PluralRule>();
-    private Map<Method, MessageDescriptor> descriptors = new HashMap<Method, MessageDescriptor>();
+    private final Map<Object, PluralRule> rules = new HashMap<Object, PluralRule>();
+    private final Map<Method, MessageDescriptor> descriptors = new HashMap<Method, MessageDescriptor>();
 
     protected MessagesProxy(Class<? extends LocalizableResource> cls) {
         super(cls);
@@ -32,7 +37,7 @@ class MessagesProxy extends LocaleProxy {
                     rules.put(getLocale(), rule);
                 }
                 return rule;
-            } else {
+			} else {
                 PluralRule rule = rules.get(cls);
                 if (rule == null) {
                     rule = cls.newInstance();
@@ -63,7 +68,7 @@ class MessagesProxy extends LocaleProxy {
         MessageDescriptor desc = getDescriptor(method);
         List<String> forms = new ArrayList<String>();
         for (int i = 0; i < desc.args.length; i++) {
-            MessageArgument arg = desc.args[i];
+			MessageArgument arg = desc.args[i];
             if (arg.pluralCount) {
                 PluralRule rule = getRule(arg.pluralRule);
                 int n = ((Number) args[i]).intValue();
@@ -96,12 +101,7 @@ class MessagesProxy extends LocaleProxy {
             log.error(String.format("Unlocalized key '%s(%s)' for locale '%s'", desc.key, forms.get(0), getLocale()));
             message = '@' + desc.key;
         }
-        if (args != null) {
-            for (int i = 0; i < args.length; i++) {
-                message = message.replaceAll("\\{" + i + "(\\,[^\\}]+)?\\}", Matcher.quoteReplacement(String.valueOf(args[i])));
-            }
-        }
-        return message;
+		return MessageFormat.format(message, args);
     }
 
     private synchronized MessageDescriptor getDescriptor(Method method) {

--- a/src/test/java/com/teklabs/gwt/i18n/server/MessagesProxyTest.java
+++ b/src/test/java/com/teklabs/gwt/i18n/server/MessagesProxyTest.java
@@ -1,10 +1,12 @@
 package com.teklabs.gwt.i18n.server;
 
-import com.teklabs.gwt.i18n.client.LocaleFactory;
+import java.util.Date;
+import java.util.Locale;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Locale;
+import com.teklabs.gwt.i18n.client.LocaleFactory;
 
 /**
  * @author Vladimir Kulev
@@ -37,4 +39,10 @@ public class MessagesProxyTest {
         Assert.assertEquals("Three selected", getMessages().select(3, "select three"));
         Assert.assertEquals("Four selected", getMessages().select(4, "select four"));
     }
+
+	@Test
+	public void dates() {
+		MessagesProxy.setLocale(new Locale("en"));
+		Assert.assertEquals("Today is January 1, 1970", getMessages().today(new Date(0)));
+	}
 }

--- a/src/test/java/com/teklabs/gwt/i18n/server/TestMessages.java
+++ b/src/test/java/com/teklabs/gwt/i18n/server/TestMessages.java
@@ -1,5 +1,7 @@
 package com.teklabs.gwt.i18n.server;
 
+import java.util.Date;
+
 import com.google.gwt.i18n.client.LocalizableResource;
 import com.google.gwt.i18n.client.Messages;
 
@@ -24,4 +26,8 @@ public interface TestMessages extends Messages {
             "=4|select four", "Four selected"
     })
     String select(@PluralCount @Offset(1) int n, @Select String select);
+
+	@DefaultMessage("Today is {0,date,long}")
+	String today(Date today);
+
 }


### PR DESCRIPTION
Hi, I've fixed MessagesProxy so that it supports date and number formatting like  "Today is {0,date,long}" or "{0,number,integer}"
