### PR TITLE
Locale passed via cookies

### DIFF
--- a/src/main/java/com/teklabs/gwt/i18n/server/I18nFilter.java
+++ b/src/main/java/com/teklabs/gwt/i18n/server/I18nFilter.java
@@ -3,6 +3,7 @@ package com.teklabs.gwt.i18n.server;
 import org.apache.commons.lang.LocaleUtils;
 
 import javax.servlet.*;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
@@ -34,6 +35,22 @@ public class I18nFilter implements Filter {
         }
         if (locale == null) {
             locale = servletRequest.getLocale();
+        }
+
+        // if locale still not set, try to get it from cookies
+        if (locale == null) {
+            Cookie[] cookies = req.getCookies();
+            String localeStr = null;
+            if (cookies != null) {
+                for (Cookie curr : cookies) {
+                    if (curr.getName().equals("locale")) {
+                        localeStr = curr.getValue();
+                    }
+                }
+            }
+            if (localeStr != null) {
+                locale = LocaleUtils.toLocale(localeStr);
+            }
         }
 
         LocaleProxy.setLocale(locale);


### PR DESCRIPTION
Hi, lightoze. 

We use Applets with our GWT application and it is very cumbersome to be able to pass the locale only via http request or http session... So I have added code to parse cookies as well. This might be very useful for others, so I am issuing a pull request...

Thanks for the library and I hope you find the addition useful and incorporate it to the next build...

Note: at the moment we are using your library, but we had to implement another filter that parses the cookies and puts the locale into the http session so your filter can read it from there...

Best regards,
Kris
