### PR TITLE
Pulled the cookie parsing before the servletRequest.getLocale()

### DIFF
--- a/src/main/java/com/teklabs/gwt/i18n/server/I18nFilter.java
+++ b/src/main/java/com/teklabs/gwt/i18n/server/I18nFilter.java
@@ -33,9 +33,6 @@ public class I18nFilter implements Filter {
                 locale = (Locale) session.getAttribute("locale");
             }
         }
-        if (locale == null) {
-            locale = servletRequest.getLocale();
-        }
 
         // if locale still not set, try to get it from cookies
         if (locale == null) {
@@ -48,6 +45,10 @@ public class I18nFilter implements Filter {
                     }
                 }
             }
+        }
+
+        if (locale == null) {
+            locale = servletRequest.getLocale();
         }
 
         LocaleProxy.setLocale(locale);


### PR DESCRIPTION
Hi, lightoze.

The added cookie code was never reached, because locale is never null when setting it to servletRequest.getLocale(). 

Please merge the new code, it works correctly now, I have tested it. Sorry for the inconvenience.
