### PR TITLE
Java 6 Support

### DIFF
--- a/src/main/java/net/lightoze/gwt/i18n/server/LocaleProxy.java
+++ b/src/main/java/net/lightoze/gwt/i18n/server/LocaleProxy.java
@@ -1,32 +1,5 @@
 package net.lightoze.gwt.i18n.server;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import net.lightoze.gwt.i18n.client.LocaleFactory;
-
-import org.apache.commons.lang.reflect.MethodUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gwt.i18n.client.Constants;
 import com.google.gwt.i18n.client.ConstantsWithLookup;
@@ -37,6 +10,25 @@ import com.google.gwt.i18n.server.impl.ReflectionMessage;
 import com.google.gwt.i18n.server.impl.ReflectionMessageInterface;
 import com.google.gwt.i18n.shared.GwtLocale;
 import com.google.gwt.i18n.shared.GwtLocaleFactory;
+
+import net.lightoze.gwt.i18n.client.LocaleFactory;
+
+import org.apache.commons.lang.reflect.MethodUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.URLDecoder;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Vladimir Kulev


### PR DESCRIPTION
Near as I can tell, get-i18n-server v0.21 will only work on JDK 7+. The compiler in the POM is set to support Java 6, but when I attempt to compile on a Java 6 environment, I get:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running ca.cpp.spike.AppTest
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.056 sec <<< FAILURE!

Results :

Tests in error:
  testGwtInternationalizationServer(ca.cpp.spike.AppTest): java/lang/ReflectiveOperationException

Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```

If you'd like this to work with Java 6, then I guess you'll need a new release recompiled to work in v1.6. Alternately, you could just be explicit that it's Java 7+.

Same problem with v0.20. v0.19 seems to work on a quick check.
